### PR TITLE
Update CFP URL Link and footer

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -27,9 +27,9 @@ const sections = [
     ],
   },
 ];
+const currentYear = new Date().getFullYear();
 
 export default function Footer() {
-  const currentYear = new Date().getFullYear();
   return (
     <section className="border-t relative overflow-hidden py-10">
       <div className="container mx-auto max-w-7xl px-8">

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -29,6 +29,7 @@ const sections = [
 ];
 
 export default function Footer() {
+  const currentYear = new Date().getFullYear();
   return (
     <section className="border-t relative overflow-hidden py-10">
       <div className="container mx-auto max-w-7xl px-8">
@@ -59,7 +60,7 @@ export default function Footer() {
             ))}
           </div>
           <div className="mt-24 flex flex-col justify-between gap-4 border-t pt-8 text-sm font-medium text-muted-foreground md:flex-row md:items-center">
-            <p>© 2025 PyConKE. All rights reserved.</p>
+            <p>© {currentYear} PyConKE. All rights reserved.</p>
             <ul className="flex gap-4">
               <li className="underline hover:text-primary">
                 <a href="/terms-and-conditions"> Terms and Conditions</a>

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -20,7 +20,7 @@ export default function HeroSection() {
             </RainbowButton>
             <RainbowGreyButton>
               <a
-                href="https://pretalx.com/pycon-kenya-2026/cfp"
+                href="https://cfp.pycon.ke/pycon-kenya-2026/"
                 target="_blank"
                 rel="noreferrer"
               >

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -20,7 +20,7 @@ export default function HeroSection() {
             </RainbowButton>
             <RainbowGreyButton>
               <a
-                href="https://cfp.pycon.ke/pycon-kenya-2026/"
+                href="https://cfp.pycon.ke/pycon-kenya-2026/cfp"
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
## Summary by Sourcery

Update the site footer to use the current year dynamically and point the hero section CFP button to the new CFP URL.

Enhancements:
- Use the current calendar year dynamically in the footer copyright text instead of a hard-coded year.

Chores:
- Update the Call for Papers button link in the hero section to the new CFP URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Footer now shows the current year automatically so copyright stays up to date.

* **Bug Fixes**
  * "Call For Speakers" link updated to the correct CFP URL so the button opens the intended submission site in a new tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->